### PR TITLE
ARTEMIS-1586 Refactor to make more generic

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/SimpleString.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/SimpleString.java
@@ -21,8 +21,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.util.internal.PlatformDependent;
-import org.apache.activemq.artemis.utils.AbstractInterner;
+import org.apache.activemq.artemis.utils.AbstractByteBufPool;
+import org.apache.activemq.artemis.utils.AbstractPool;
+import org.apache.activemq.artemis.utils.ByteUtil;
 import org.apache.activemq.artemis.utils.DataConstants;
 
 /**
@@ -32,129 +33,6 @@ import org.apache.activemq.artemis.utils.DataConstants;
  * This object is used heavily throughout ActiveMQ Artemis for performance reasons.
  */
 public final class SimpleString implements CharSequence, Serializable, Comparable<SimpleString> {
-
-   public static final class Interner extends AbstractInterner<SimpleString> {
-
-      private final int maxLength;
-
-      public Interner(final int capacity, final int maxCharsLength) {
-         super(capacity);
-         this.maxLength = maxCharsLength;
-      }
-
-      @Override
-      protected boolean isEqual(final SimpleString entry, final ByteBuf byteBuf, final int offset, final int length) {
-         return SimpleString.isEqual(entry, byteBuf, offset, length);
-      }
-
-      @Override
-      protected boolean canIntern(final ByteBuf byteBuf, final int length) {
-         assert length % 2 == 0 : "length must be a multiple of 2";
-         final int expectedStringLength = length >> 1;
-         return expectedStringLength <= maxLength;
-      }
-
-      @Override
-      protected SimpleString create(final ByteBuf byteBuf, final int length) {
-         return readSimpleString(byteBuf, length);
-      }
-   }
-
-   /**
-    * Returns {@code true} if  the {@link SimpleString} encoded content into {@code bytes} is equals to {@code s},
-    * {@code false} otherwise.
-    * <p>
-    * It assumes that the {@code bytes} content is read using {@link SimpleString#readSimpleString(ByteBuf, int)} ie starting right after the
-    * length field.
-    */
-   public static boolean isEqual(final SimpleString s, final ByteBuf bytes, final int offset, final int length) {
-      if (s == null) {
-         return false;
-      }
-      final byte[] chars = s.getData();
-      if (chars.length != length)
-         return false;
-      if (PlatformDependent.isUnaligned() && PlatformDependent.hasUnsafe()) {
-         if ((offset + length) > bytes.writerIndex()) {
-            throw new IndexOutOfBoundsException();
-         }
-         if (bytes.hasArray()) {
-            return batchOnHeapIsEqual(chars, bytes.array(), bytes.arrayOffset() + offset, length);
-         } else if (bytes.hasMemoryAddress()) {
-            return batchOffHeapIsEqual(chars, bytes.memoryAddress(), offset, length);
-         }
-      }
-      return byteBufIsEqual(chars, bytes, offset, length);
-   }
-
-   private static boolean byteBufIsEqual(final byte[] chars, final ByteBuf bytes, final int offset, final int length) {
-      for (int i = 0; i < length; i++)
-         if (chars[i] != bytes.getByte(offset + i))
-            return false;
-      return true;
-   }
-
-   private static boolean batchOnHeapIsEqual(final byte[] chars,
-                                             final byte[] array,
-                                             final int arrayOffset,
-                                             final int length) {
-      final int longCount = length >>> 3;
-      final int bytesCount = length & 7;
-      int bytesIndex = arrayOffset;
-      int charsIndex = 0;
-      for (int i = 0; i < longCount; i++) {
-         final long charsLong = PlatformDependent.getLong(chars, charsIndex);
-         final long bytesLong = PlatformDependent.getLong(array, bytesIndex);
-         if (charsLong != bytesLong) {
-            return false;
-
-         }
-         bytesIndex += 8;
-         charsIndex += 8;
-      }
-      for (int i = 0; i < bytesCount; i++) {
-         final byte charsByte = PlatformDependent.getByte(chars, charsIndex);
-         final byte bytesByte = PlatformDependent.getByte(array, bytesIndex);
-         if (charsByte != bytesByte) {
-            return false;
-
-         }
-         bytesIndex++;
-         charsIndex++;
-      }
-      return true;
-   }
-
-   private static boolean batchOffHeapIsEqual(final byte[] chars,
-                                              final long address,
-                                              final int offset,
-                                              final int length) {
-      final int longCount = length >>> 3;
-      final int bytesCount = length & 7;
-      long bytesAddress = address + offset;
-      int charsIndex = 0;
-      for (int i = 0; i < longCount; i++) {
-         final long charsLong = PlatformDependent.getLong(chars, charsIndex);
-         final long bytesLong = PlatformDependent.getLong(bytesAddress);
-         if (charsLong != bytesLong) {
-            return false;
-
-         }
-         bytesAddress += 8;
-         charsIndex += 8;
-      }
-      for (int i = 0; i < bytesCount; i++) {
-         final byte charsByte = PlatformDependent.getByte(chars, charsIndex);
-         final byte bytesByte = PlatformDependent.getByte(bytesAddress);
-         if (charsByte != bytesByte) {
-            return false;
-
-         }
-         bytesAddress++;
-         charsIndex++;
-      }
-      return true;
-   }
 
    private static final long serialVersionUID = 4204223851422244307L;
 
@@ -183,6 +61,13 @@ public final class SimpleString implements CharSequence, Serializable, Comparabl
          return null;
       }
       return new SimpleString(string);
+   }
+
+   public static SimpleString toSimpleString(final String string, StringSimpleStringPool pool) {
+      if (pool == null) {
+         return toSimpleString(string);
+      }
+      return pool.getOrCreate(string);
    }
 
    // Constructors
@@ -270,6 +155,13 @@ public final class SimpleString implements CharSequence, Serializable, Comparabl
    public static SimpleString readSimpleString(ByteBuf buffer) {
       int len = buffer.readInt();
       return readSimpleString(buffer, len);
+   }
+
+   public static SimpleString readSimpleString(ByteBuf buffer, ByteBufSimpleStringPool pool) {
+      if (pool == null) {
+         return readSimpleString(buffer);
+      }
+      return pool.getOrCreate(buffer);
    }
 
    public static SimpleString readSimpleString(final ByteBuf buffer, final int length) {
@@ -381,20 +273,35 @@ public final class SimpleString implements CharSequence, Serializable, Comparabl
       if (other instanceof SimpleString) {
          SimpleString s = (SimpleString) other;
 
-         if (data.length != s.data.length) {
-            return false;
-         }
-
-         for (int i = 0; i < data.length; i++) {
-            if (data[i] != s.data[i]) {
-               return false;
-            }
-         }
-
-         return true;
+         return equals(s.data);
       } else {
          return false;
       }
+   }
+
+   public boolean equals(final String value) {
+      if (this.str != null) {
+         return this.str.equals(value);
+      } else {
+         if (value == null)
+            return false;
+         for (int i = 0, size = value.length(); i < size; i++) {
+            if (value.charAt(i) != this.charAt(i))
+               return false;
+         }
+         return true;
+      }
+   }
+
+   /**
+    * Returns {@code true} if  the {@link SimpleString} encoded content into {@code bytes} is equals to {@code s},
+    * {@code false} otherwise.
+    * <p>
+    * It assumes that the {@code bytes} content is read using {@link SimpleString#readSimpleString(ByteBuf, int)} ie starting right after the
+    * length field.
+    */
+   public boolean equals(final ByteBuf byteBuf, final int offset, final int length) {
+      return ByteUtil.equals(data, byteBuf, offset, length);
    }
 
    @Override
@@ -573,6 +480,66 @@ public final class SimpleString implements CharSequence, Serializable, Comparabl
          int high = data[j++] << 8 & 0xFF00;
 
          dst[d++] = (char) (low | high);
+      }
+   }
+
+   public static final class ByteBufSimpleStringPool extends AbstractByteBufPool<SimpleString> {
+
+      private static final int UUID_LENGTH = 36;
+
+      private final int maxLength;
+
+      public ByteBufSimpleStringPool() {
+         this.maxLength = UUID_LENGTH;
+      }
+
+      public ByteBufSimpleStringPool(final int capacity, final int maxCharsLength) {
+         super(capacity);
+         this.maxLength = maxCharsLength;
+      }
+
+      @Override
+      protected boolean isEqual(final SimpleString entry, final ByteBuf byteBuf, final int offset, final int length) {
+         if (entry == null) {
+            return false;
+         }
+         return entry.equals(byteBuf, offset, length);
+      }
+
+      @Override
+      protected boolean canPool(final ByteBuf byteBuf, final int length) {
+         assert length % 2 == 0 : "length must be a multiple of 2";
+         final int expectedStringLength = length >> 1;
+         return expectedStringLength <= maxLength;
+      }
+
+      @Override
+      protected SimpleString create(final ByteBuf byteBuf, final int length) {
+         return readSimpleString(byteBuf, length);
+      }
+   }
+
+   public static final class StringSimpleStringPool extends AbstractPool<String, SimpleString> {
+
+      public StringSimpleStringPool() {
+         super();
+      }
+
+      public StringSimpleStringPool(final int capacity) {
+         super(capacity);
+      }
+
+      @Override
+      protected SimpleString create(String value) {
+         return toSimpleString(value);
+      }
+
+      @Override
+      protected boolean isEqual(SimpleString entry, String value) {
+         if (entry == null) {
+            return false;
+         }
+         return entry.equals(value);
       }
    }
 }

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/AbstractPool.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/AbstractPool.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.utils;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.internal.MathUtil;
+
+/**
+ * Thread-safe {@code <T>} interner.
+ * <p>
+ * Differently from {@link String#intern()} it contains a fixed amount of entries and
+ * when used by concurrent threads it doesn't ensure the uniqueness of the entries ie
+ * the same entry could be allocated multiple times by concurrent calls.
+ */
+public abstract class AbstractPool<I, O> {
+
+   public static final int DEFAULT_POOL_CAPACITY = 32;
+
+   private final O[] entries;
+   private final int mask;
+   private final int shift;
+
+   public AbstractPool() {
+      this(DEFAULT_POOL_CAPACITY);
+   }
+
+   public AbstractPool(final int capacity) {
+      entries = (O[]) new Object[MathUtil.findNextPositivePowerOfTwo(capacity)];
+      mask = entries.length - 1;
+      //log2 of entries.length
+      shift = 31 - Integer.numberOfLeadingZeros(entries.length);
+   }
+
+   /**
+    * Create a new entry.
+    */
+   protected abstract O create(I value);
+
+   /**
+    * Returns {@code true} if the {@code entry} content is equal to {@code value};
+    */
+   protected abstract boolean isEqual(O entry, I value);
+
+   protected int hashCode(I value){
+      return value.hashCode();
+   }
+
+   /**
+    * Returns and interned entry if possible, a new one otherwise.
+    * <p>
+    * The {@code byteBuf}'s {@link ByteBuf#readerIndex()} is incremented by {@code length} after it.
+    */
+   public final O getOrCreate(final I value) {
+      if (value == null) {
+         return null;
+      }
+      final int hashCode = hashCode(value);
+      //fast % operation with power of 2 entries.length
+      final int firstIndex = hashCode & mask;
+      final O firstEntry = entries[firstIndex];
+      if (isEqual(firstEntry, value)) {
+         return firstEntry;
+      }
+      final int secondIndex = (hashCode >> shift) & mask;
+      final O secondEntry = entries[secondIndex];
+      if (isEqual(secondEntry, value)) {
+         return secondEntry;
+      }
+      final O internedEntry = create(value);
+      final int entryIndex = firstEntry == null ? firstIndex : secondIndex;
+      entries[entryIndex] = internedEntry;
+      return internedEntry;
+   }
+}

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/collections/TypedProperties.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/collections/TypedProperties.java
@@ -28,7 +28,8 @@ import io.netty.buffer.ByteBuf;
 import org.apache.activemq.artemis.api.core.ActiveMQPropertyConversionException;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.logs.ActiveMQUtilBundle;
-import org.apache.activemq.artemis.utils.AbstractInterner;
+import org.apache.activemq.artemis.utils.AbstractByteBufPool;
+import org.apache.activemq.artemis.utils.AbstractPool;
 import org.apache.activemq.artemis.utils.ByteUtil;
 import org.apache.activemq.artemis.utils.DataConstants;
 
@@ -332,8 +333,7 @@ public class TypedProperties {
    }
 
    public synchronized void decode(final ByteBuf buffer,
-                                   final SimpleString.Interner keyInterner,
-                                   final StringValue.Interner valueInterner) {
+                                   final TypedPropertiesDecoderPools keyValuePools) {
       byte b = buffer.readByte();
 
       if (b == DataConstants.NULL) {
@@ -346,15 +346,7 @@ public class TypedProperties {
          size = 0;
 
          for (int i = 0; i < numHeaders; i++) {
-            final SimpleString key;
-            int len = buffer.readInt();
-            if (keyInterner != null) {
-               key = keyInterner.intern(buffer, len);
-            } else {
-               byte[] data = new byte[len];
-               buffer.readBytes(data);
-               key = new SimpleString(data);
-            }
+            final SimpleString key = SimpleString.readSimpleString(buffer, keyValuePools == null ? null : keyValuePools.getPropertyKeysPool());
 
             byte type = buffer.readByte();
 
@@ -412,12 +404,7 @@ public class TypedProperties {
                   break;
                }
                case STRING: {
-                  if (valueInterner != null) {
-                     final int length = buffer.readInt();
-                     val = valueInterner.intern(buffer, length);
-                  } else {
-                     val = new StringValue(buffer);
-                  }
+                  val = StringValue.readStringValue(buffer, keyValuePools == null ? null : keyValuePools.getPropertyValuesPool());
                   doPutValue(key, val);
                   break;
                }
@@ -430,7 +417,7 @@ public class TypedProperties {
    }
 
    public synchronized void decode(final ByteBuf buffer) {
-      decode(buffer, null, null);
+      decode(buffer, null);
    }
 
    public synchronized void encode(final ByteBuf buffer) {
@@ -901,44 +888,18 @@ public class TypedProperties {
 
    public static final class StringValue extends PropertyValue {
 
-      public static final class Interner extends AbstractInterner<StringValue> {
-
-         private final int maxLength;
-
-         public Interner(final int capacity, final int maxCharsLength) {
-            super(capacity);
-            this.maxLength = maxCharsLength;
-         }
-
-         @Override
-         protected boolean isEqual(final StringValue entry, final ByteBuf byteBuf, final int offset, final int length) {
-            if (entry == null) {
-               return false;
-            }
-            return SimpleString.isEqual(entry.val, byteBuf, offset, length);
-         }
-
-         @Override
-         protected boolean canIntern(final ByteBuf byteBuf, final int length) {
-            assert length % 2 == 0 : "length must be a multiple of 2";
-            final int expectedStringLength = length >> 1;
-            return expectedStringLength <= maxLength;
-         }
-
-         @Override
-         protected StringValue create(final ByteBuf byteBuf, final int length) {
-            return new StringValue(SimpleString.readSimpleString(byteBuf, length));
-         }
-      }
-
       final SimpleString val;
 
       private StringValue(final SimpleString val) {
          this.val = val;
       }
 
-      private StringValue(final ByteBuf buffer) {
-         val = SimpleString.readSimpleString(buffer);
+      static StringValue readStringValue(final ByteBuf byteBuf, ByteBufStringValuePool pool) {
+         if (pool == null) {
+            return new StringValue(SimpleString.readSimpleString(byteBuf));
+         } else {
+            return pool.getOrCreate(byteBuf);
+         }
       }
 
       @Override
@@ -955,6 +916,116 @@ public class TypedProperties {
       @Override
       public int encodeSize() {
          return DataConstants.SIZE_BYTE + SimpleString.sizeofString(val);
+      }
+
+      public static final class ByteBufStringValuePool extends AbstractByteBufPool<StringValue> {
+
+         private static final int UUID_LENGTH = 36;
+
+         private final int maxLength;
+
+         public ByteBufStringValuePool() {
+            this.maxLength = UUID_LENGTH;
+         }
+
+         public ByteBufStringValuePool(final int capacity, final int maxCharsLength) {
+            super(capacity);
+            this.maxLength = maxCharsLength;
+         }
+
+         @Override
+         protected boolean isEqual(final StringValue entry, final ByteBuf byteBuf, final int offset, final int length) {
+            if (entry == null || entry.val == null) {
+               return false;
+            }
+            return entry.val.equals(byteBuf, offset, length);
+         }
+
+         @Override
+         protected boolean canPool(final ByteBuf byteBuf, final int length) {
+            assert length % 2 == 0 : "length must be a multiple of 2";
+            final int expectedStringLength = length >> 1;
+            return expectedStringLength <= maxLength;
+         }
+
+         @Override
+         protected StringValue create(final ByteBuf byteBuf, final int length) {
+            return new StringValue(SimpleString.readSimpleString(byteBuf, length));
+         }
+      }
+
+      public static final class StringStringValuePool extends AbstractPool<String, StringValue> {
+
+         public StringStringValuePool() {
+            super();
+         }
+
+         public StringStringValuePool(final int capacity) {
+            super(capacity);
+         }
+
+         @Override
+         protected StringValue create(String value) {
+            return new StringValue(SimpleString.toSimpleString(value));
+         }
+
+         @Override
+         protected boolean isEqual(StringValue entry, String value) {
+            if (entry == null || entry.val == null) {
+               return false;
+            }
+            return entry.val.equals(value);
+         }
+
+
+      }
+   }
+
+   public static class TypedPropertiesDecoderPools {
+
+      private SimpleString.ByteBufSimpleStringPool propertyKeysPool;
+      private TypedProperties.StringValue.ByteBufStringValuePool propertyValuesPool;
+
+      public TypedPropertiesDecoderPools() {
+         this.propertyKeysPool = new SimpleString.ByteBufSimpleStringPool();
+         this.propertyValuesPool = new TypedProperties.StringValue.ByteBufStringValuePool();
+      }
+
+      public TypedPropertiesDecoderPools(int keyPoolCapacity, int valuePoolCapacity, int maxCharsLength) {
+         this.propertyKeysPool = new SimpleString.ByteBufSimpleStringPool(keyPoolCapacity, maxCharsLength);
+         this.propertyValuesPool = new TypedProperties.StringValue.ByteBufStringValuePool(valuePoolCapacity, maxCharsLength);
+      }
+
+      public SimpleString.ByteBufSimpleStringPool getPropertyKeysPool() {
+         return propertyKeysPool;
+      }
+
+      public TypedProperties.StringValue.ByteBufStringValuePool getPropertyValuesPool() {
+         return propertyValuesPool;
+      }
+   }
+
+   public static class TypedPropertiesStringSimpleStringPools {
+
+      private SimpleString.StringSimpleStringPool propertyKeysPool;
+      private SimpleString.StringSimpleStringPool propertyValuesPool;
+
+      public TypedPropertiesStringSimpleStringPools() {
+         this.propertyKeysPool = new SimpleString.StringSimpleStringPool();
+         this.propertyValuesPool = new SimpleString.StringSimpleStringPool();
+      }
+
+      public TypedPropertiesStringSimpleStringPools(int keyPoolCapacity, int valuePoolCapacity) {
+         this.propertyKeysPool = new SimpleString.StringSimpleStringPool(keyPoolCapacity);
+         this.propertyValuesPool = new SimpleString.StringSimpleStringPool(valuePoolCapacity);
+      }
+
+      public SimpleString.StringSimpleStringPool getPropertyKeysPool() {
+         return propertyKeysPool;
+      }
+
+      public SimpleString.StringSimpleStringPool getPropertyValuesPool() {
+         return propertyValuesPool;
       }
    }
 

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientMessageImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientMessageImpl.java
@@ -30,6 +30,7 @@ import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.client.ActiveMQClientMessageBundle;
 import org.apache.activemq.artemis.core.message.LargeBodyEncoder;
 import org.apache.activemq.artemis.core.message.impl.CoreMessage;
+import org.apache.activemq.artemis.core.message.impl.CoreMessageObjectPools;
 import org.apache.activemq.artemis.reader.MessageUtil;
 import org.apache.activemq.artemis.utils.UUID;
 import org.apache.activemq.artemis.utils.collections.TypedProperties;
@@ -57,6 +58,10 @@ public class ClientMessageImpl extends CoreMessage implements ClientMessageInter
     * Constructor for when reading from remoting
     */
    public ClientMessageImpl() {
+   }
+
+   public ClientMessageImpl(CoreMessageObjectPools coreMessageObjectPools) {
+      super(coreMessageObjectPools);
    }
 
    protected ClientMessageImpl(ClientMessageImpl other) {
@@ -96,9 +101,20 @@ public class ClientMessageImpl extends CoreMessage implements ClientMessageInter
                             final long expiration,
                             final long timestamp,
                             final byte priority,
-                            final int initialMessageBufferSize) {
+                            final int initialMessageBufferSize,
+                            final CoreMessageObjectPools coreMessageObjectPools) {
+      super(coreMessageObjectPools);
       this.setType(type).setExpiration(expiration).setTimestamp(timestamp).setDurable(durable).
            setPriority(priority).initBuffer(initialMessageBufferSize);
+   }
+
+   public ClientMessageImpl(final byte type,
+                            final boolean durable,
+                            final long expiration,
+                            final long timestamp,
+                            final byte priority,
+                            final int initialMessageBufferSize) {
+      this(type, durable, expiration, timestamp, priority, initialMessageBufferSize, null);
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionImpl.java
@@ -43,6 +43,7 @@ import org.apache.activemq.artemis.api.core.client.SendAcknowledgementHandler;
 import org.apache.activemq.artemis.api.core.client.SessionFailureListener;
 import org.apache.activemq.artemis.core.client.ActiveMQClientLogger;
 import org.apache.activemq.artemis.core.client.ActiveMQClientMessageBundle;
+import org.apache.activemq.artemis.core.message.impl.CoreMessageObjectPools;
 import org.apache.activemq.artemis.core.remoting.FailureListener;
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
@@ -147,6 +148,8 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
    private final ConfirmationWindowWarning confirmationWindowWarning;
 
    private final Executor closeExecutor;
+
+   private final CoreMessageObjectPools coreMessageObjectPools = new CoreMessageObjectPools();
 
    ClientSessionImpl(final ClientSessionFactoryInternal sessionFactory,
                      final String name,
@@ -869,7 +872,7 @@ public final class ClientSessionImpl implements ClientSessionInternal, FailureLi
                                       final long expiration,
                                       final long timestamp,
                                       final byte priority) {
-      return new ClientMessageImpl(type, durable, expiration, timestamp, priority, initialMessagePacketSize);
+      return new ClientMessageImpl(type, durable, expiration, timestamp, priority, initialMessagePacketSize, coreMessageObjectPools);
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessage.java
@@ -93,18 +93,14 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
 
    protected volatile TypedProperties properties;
 
-   private final SimpleString.Interner keysInterner;
-   private final TypedProperties.StringValue.Interner valuesInterner;
+   private final CoreMessageObjectPools coreMessageObjectPools;
 
-   public CoreMessage(final SimpleString.Interner keysInterner,
-                      final TypedProperties.StringValue.Interner valuesInterner) {
-      this.keysInterner = keysInterner;
-      this.valuesInterner = valuesInterner;
+   public CoreMessage(final CoreMessageObjectPools coreMessageObjectPools) {
+      this.coreMessageObjectPools = coreMessageObjectPools;
    }
 
    public CoreMessage() {
-      this.keysInterner = null;
-      this.valuesInterner = null;
+      this.coreMessageObjectPools = null;
    }
 
    /** On core there's no delivery annotation */
@@ -328,8 +324,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
    public CoreMessage(long id, int bufferSize) {
       this.initBuffer(bufferSize);
       this.setMessageID(id);
-      this.keysInterner = null;
-      this.valuesInterner = null;
+      this.coreMessageObjectPools = null;
    }
 
    protected CoreMessage(CoreMessage other, TypedProperties copyProperties) {
@@ -343,8 +338,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
       this.timestamp = other.timestamp;
       this.priority = other.priority;
       this.userID = other.userID;
-      this.keysInterner = other.keysInterner;
-      this.valuesInterner = other.valuesInterner;
+      this.coreMessageObjectPools = other.coreMessageObjectPools;
       if (copyProperties != null) {
          this.properties = new TypedProperties(copyProperties);
       }
@@ -424,7 +418,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
 
    @Override
    public CoreMessage setValidatedUserID(String validatedUserID) {
-      putStringProperty(Message.HDR_VALIDATED_USER, SimpleString.toSimpleString(validatedUserID));
+      putStringProperty(Message.HDR_VALIDATED_USER, SimpleString.toSimpleString(validatedUserID, getPropertyValuesPool()));
       return this;
    }
 
@@ -479,7 +473,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
          TypedProperties properties = new TypedProperties();
          if (buffer != null && propertiesLocation >= 0) {
             final ByteBuf byteBuf = buffer.duplicate().readerIndex(propertiesLocation);
-            properties.decode(byteBuf, keysInterner, valuesInterner);
+            properties.decode(byteBuf, coreMessageObjectPools == null ? null : coreMessageObjectPools.getPropertiesDecoderPools());
          }
          this.properties = properties;
       }
@@ -545,12 +539,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
       messageID = buffer.readLong();
       int b = buffer.readByte();
       if (b != DataConstants.NULL) {
-         final int length = buffer.readInt();
-         if (keysInterner != null) {
-            address = keysInterner.intern(buffer, length);
-         } else {
-            address = SimpleString.readSimpleString(buffer, length);
-         }
+         address = SimpleString.readSimpleString(buffer, coreMessageObjectPools == null ? null : coreMessageObjectPools.getAddressDecoderPool());
       } else {
          address = null;
       }
@@ -571,7 +560,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
          propertiesLocation = buffer.readerIndex();
       } else {
          properties = new TypedProperties();
-         properties.decode(buffer, keysInterner, valuesInterner);
+         properties.decode(buffer, coreMessageObjectPools == null ? null : coreMessageObjectPools.getPropertiesDecoderPools());
       }
    }
 
@@ -671,7 +660,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
    @Override
    public CoreMessage setAddress(String address) {
       messageChanged();
-      this.address = SimpleString.toSimpleString(address);
+      this.address = SimpleString.toSimpleString(address, coreMessageObjectPools == null ? null : coreMessageObjectPools.getAddressStringSimpleStringPool());
       return this;
    }
 
@@ -703,7 +692,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
    public CoreMessage putBooleanProperty(final String key, final boolean value) {
       messageChanged();
       checkProperties();
-      properties.putBooleanProperty(new SimpleString(key), value);
+      properties.putBooleanProperty(SimpleString.toSimpleString(key, getPropertyKeysPool()), value);
       return this;
    }
 
@@ -724,7 +713,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
    @Override
    public Boolean getBooleanProperty(final String key) throws ActiveMQPropertyConversionException {
       checkProperties();
-      return properties.getBooleanProperty(new SimpleString(key));
+      return properties.getBooleanProperty(SimpleString.toSimpleString(key, getPropertyKeysPool()));
    }
 
    @Override
@@ -739,7 +728,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
    public CoreMessage putByteProperty(final String key, final byte value) {
       messageChanged();
       checkProperties();
-      properties.putByteProperty(new SimpleString(key), value);
+      properties.putByteProperty(SimpleString.toSimpleString(key, getPropertyKeysPool()), value);
 
       return this;
    }
@@ -752,7 +741,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
 
    @Override
    public Byte getByteProperty(final String key) throws ActiveMQPropertyConversionException {
-      return getByteProperty(SimpleString.toSimpleString(key));
+      return getByteProperty(SimpleString.toSimpleString(key, getPropertyKeysPool()));
    }
 
    @Override
@@ -768,7 +757,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
    public CoreMessage putBytesProperty(final String key, final byte[] value) {
       messageChanged();
       checkProperties();
-      properties.putBytesProperty(new SimpleString(key), value);
+      properties.putBytesProperty(SimpleString.toSimpleString(key, getPropertyKeysPool()), value);
       return this;
    }
 
@@ -780,7 +769,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
 
    @Override
    public byte[] getBytesProperty(final String key) throws ActiveMQPropertyConversionException {
-      return getBytesProperty(new SimpleString(key));
+      return getBytesProperty(SimpleString.toSimpleString(key, getPropertyKeysPool()));
    }
 
    @Override
@@ -795,7 +784,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
    public CoreMessage putCharProperty(String key, char value) {
       messageChanged();
       checkProperties();
-      properties.putCharProperty(new SimpleString(key), value);
+      properties.putCharProperty(SimpleString.toSimpleString(key, getPropertyKeysPool()), value);
       return this;
    }
 
@@ -811,7 +800,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
    public CoreMessage putShortProperty(final String key, final short value) {
       messageChanged();
       checkProperties();
-      properties.putShortProperty(new SimpleString(key), value);
+      properties.putShortProperty(SimpleString.toSimpleString(key, getPropertyKeysPool()), value);
       return this;
    }
 
@@ -827,7 +816,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
    public CoreMessage putIntProperty(final String key, final int value) {
       messageChanged();
       checkProperties();
-      properties.putIntProperty(new SimpleString(key), value);
+      properties.putIntProperty(SimpleString.toSimpleString(key, getPropertyKeysPool()), value);
       return this;
    }
 
@@ -854,7 +843,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
    public CoreMessage putLongProperty(final String key, final long value) {
       messageChanged();
       checkProperties();
-      properties.putLongProperty(new SimpleString(key), value);
+      properties.putLongProperty(SimpleString.toSimpleString(key, getPropertyKeysPool()), value);
       return this;
    }
 
@@ -882,7 +871,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
    public CoreMessage putFloatProperty(final String key, final float value) {
       messageChanged();
       checkProperties();
-      properties.putFloatProperty(new SimpleString(key), value);
+      properties.putFloatProperty(SimpleString.toSimpleString(key, getPropertyKeysPool()), value);
       return this;
    }
 
@@ -898,7 +887,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
    public CoreMessage putDoubleProperty(final String key, final double value) {
       messageChanged();
       checkProperties();
-      properties.putDoubleProperty(new SimpleString(key), value);
+      properties.putDoubleProperty(SimpleString.toSimpleString(key, getPropertyKeysPool()), value);
       return this;
    }
 
@@ -927,7 +916,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
    public CoreMessage putStringProperty(final String key, final String value) {
       messageChanged();
       checkProperties();
-      properties.putSimpleStringProperty(new SimpleString(key), SimpleString.toSimpleString(value));
+      properties.putSimpleStringProperty(SimpleString.toSimpleString(key, getPropertyKeysPool()), SimpleString.toSimpleString(value, getPropertyValuesPool()));
       return this;
    }
 
@@ -943,7 +932,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
    @Override
    public Object getObjectProperty(final String key) {
       checkProperties();
-      return getObjectProperty(SimpleString.toSimpleString(key));
+      return getObjectProperty(SimpleString.toSimpleString(key, getPropertyKeysPool()));
    }
 
    @Override
@@ -955,7 +944,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
    @Override
    public CoreMessage putObjectProperty(final String key, final Object value) throws ActiveMQPropertyConversionException {
       messageChanged();
-      putObjectProperty(new SimpleString(key), value);
+      putObjectProperty(SimpleString.toSimpleString(key, getPropertyKeysPool()), value);
       return this;
    }
 
@@ -968,7 +957,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
    @Override
    public Short getShortProperty(final String key) throws ActiveMQPropertyConversionException {
       checkProperties();
-      return properties.getShortProperty(new SimpleString(key));
+      return properties.getShortProperty(SimpleString.toSimpleString(key, getPropertyKeysPool()));
    }
 
    @Override
@@ -980,7 +969,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
    @Override
    public Float getFloatProperty(final String key) throws ActiveMQPropertyConversionException {
       checkProperties();
-      return properties.getFloatProperty(new SimpleString(key));
+      return properties.getFloatProperty(SimpleString.toSimpleString(key, getPropertyKeysPool()));
    }
 
    @Override
@@ -996,7 +985,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
 
    @Override
    public String getStringProperty(final String key) throws ActiveMQPropertyConversionException {
-      return getStringProperty(new SimpleString(key));
+      return getStringProperty(SimpleString.toSimpleString(key, getPropertyKeysPool()));
    }
 
    @Override
@@ -1008,7 +997,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
    @Override
    public SimpleString getSimpleStringProperty(final String key) throws ActiveMQPropertyConversionException {
       checkProperties();
-      return properties.getSimpleStringProperty(new SimpleString(key));
+      return properties.getSimpleStringProperty(SimpleString.toSimpleString(key, getPropertyKeysPool()));
    }
 
    @Override
@@ -1025,7 +1014,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
    public Object removeProperty(final String key) {
       messageChanged();
       checkProperties();
-      Object oldValue = properties.removeProperty(new SimpleString(key));
+      Object oldValue = properties.removeProperty(SimpleString.toSimpleString(key, getPropertyKeysPool()));
       if (oldValue != null) {
          messageChanged();
       }
@@ -1041,7 +1030,7 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
    @Override
    public boolean containsProperty(final String key) {
       checkProperties();
-      return properties.containsProperty(new SimpleString(key));
+      return properties.containsProperty(SimpleString.toSimpleString(key, getPropertyKeysPool()));
    }
 
    @Override
@@ -1134,5 +1123,13 @@ public class CoreMessage extends RefCountMessage implements ICoreMessage {
       } else {
          return new java.util.Date(timestamp).toString();
       }
+   }
+
+   public SimpleString.StringSimpleStringPool getPropertyKeysPool() {
+      return coreMessageObjectPools == null ? null : coreMessageObjectPools.getPropertiesStringSimpleStringPools().getPropertyKeysPool();
+   }
+
+   public SimpleString.StringSimpleStringPool getPropertyValuesPool() {
+      return coreMessageObjectPools == null ? null : coreMessageObjectPools.getPropertiesStringSimpleStringPools().getPropertyValuesPool();
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessageObjectPools.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/impl/CoreMessageObjectPools.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.message.impl;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.utils.collections.TypedProperties;
+
+public class CoreMessageObjectPools {
+
+   private Supplier<SimpleString.ByteBufSimpleStringPool> addressDecoderPool = Suppliers.memoize(SimpleString.ByteBufSimpleStringPool::new);
+   private Supplier<TypedProperties.TypedPropertiesDecoderPools> propertiesDecoderPools = Suppliers.memoize(TypedProperties.TypedPropertiesDecoderPools::new);
+
+   private Supplier<SimpleString.StringSimpleStringPool> addressStringSimpleStringPool = Suppliers.memoize(SimpleString.StringSimpleStringPool::new);
+   private Supplier<TypedProperties.TypedPropertiesStringSimpleStringPools> propertiesStringSimpleStringPools = Suppliers.memoize(TypedProperties.TypedPropertiesStringSimpleStringPools::new);
+
+   public CoreMessageObjectPools() {
+   }
+
+   public SimpleString.ByteBufSimpleStringPool getAddressDecoderPool() {
+      return addressDecoderPool.get();
+   }
+
+   public SimpleString.StringSimpleStringPool getAddressStringSimpleStringPool() {
+      return addressStringSimpleStringPool.get();
+   }
+
+
+   public TypedProperties.TypedPropertiesDecoderPools getPropertiesDecoderPools() {
+      return propertiesDecoderPools.get();
+   }
+
+   public TypedProperties.TypedPropertiesStringSimpleStringPools getPropertiesStringSimpleStringPools() {
+      return propertiesStringSimpleStringPools.get();
+   }
+}

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/ClientPacketDecoder.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/ClientPacketDecoder.java
@@ -19,6 +19,7 @@ package org.apache.activemq.artemis.core.protocol;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.core.client.impl.ClientLargeMessageImpl;
 import org.apache.activemq.artemis.core.client.impl.ClientMessageImpl;
+import org.apache.activemq.artemis.core.message.impl.CoreMessageObjectPools;
 import org.apache.activemq.artemis.core.protocol.core.CoreRemotingConnection;
 import org.apache.activemq.artemis.core.protocol.core.Packet;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketDecoder;
@@ -32,11 +33,7 @@ import static org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl.SES
 public class ClientPacketDecoder extends PacketDecoder {
 
    private static final long serialVersionUID = 6952614096979334582L;
-   public static final ClientPacketDecoder INSTANCE = new ClientPacketDecoder();
-
-   protected ClientPacketDecoder() {
-
-   }
+   protected final CoreMessageObjectPools coreMessageObjectPools = new CoreMessageObjectPools();
 
    @Override
    public Packet decode(final ActiveMQBuffer in, CoreRemotingConnection connection) {
@@ -56,9 +53,9 @@ public class ClientPacketDecoder extends PacketDecoder {
       switch (packetType) {
          case SESS_RECEIVE_MSG: {
             if (connection.isVersionBeforeAddressChange()) {
-               packet = new SessionReceiveMessage_1X(new ClientMessageImpl());
+               packet = new SessionReceiveMessage_1X(new ClientMessageImpl(coreMessageObjectPools));
             } else {
-               packet = new SessionReceiveMessage(new ClientMessageImpl());
+               packet = new SessionReceiveMessage(new ClientMessageImpl(coreMessageObjectPools));
             }
             break;
          }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ActiveMQClientProtocolManager.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ActiveMQClientProtocolManager.java
@@ -511,7 +511,7 @@ public class ActiveMQClientProtocolManager implements ClientProtocolManager {
    }
 
    protected PacketDecoder createPacketDecoder() {
-      return ClientPacketDecoder.INSTANCE;
+      return new ClientPacketDecoder();
    }
 
    private void forceReturnChannel1(ActiveMQException cause) {

--- a/artemis-core-client/src/test/java/org/apache/activemq/artemis/message/CoreMessageTest.java
+++ b/artemis-core-client/src/test/java/org/apache/activemq/artemis/message/CoreMessageTest.java
@@ -337,7 +337,7 @@ public class CoreMessageTest {
 
    public String generate(String body) throws Exception {
 
-      ClientMessageImpl message = new ClientMessageImpl(MESSAGE_TYPE, DURABLE, EXPIRATION, TIMESTAMP, PRIORITY, 10 * 1024);
+      ClientMessageImpl message = new ClientMessageImpl(MESSAGE_TYPE, DURABLE, EXPIRATION, TIMESTAMP, PRIORITY, 10 * 1024, null);
       TextMessageUtil.writeBodyText(message.getBodyBuffer(), SimpleString.toSimpleString(body));
 
       message.setAddress(ADDRESS);

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQStreamMessage.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQStreamMessage.java
@@ -73,7 +73,7 @@ public final class ActiveMQStreamMessage extends ActiveMQMessage implements Stre
 
    // For testing only
    public ActiveMQStreamMessage() {
-      message = new ClientMessageImpl((byte) 0, false, 0, 0, (byte) 4, 1500);
+      message = new ClientMessageImpl((byte) 0, false, 0, 0, (byte) 4, 1500, null);
    }
 
    // Public --------------------------------------------------------

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/ServerPacketDecoder.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/ServerPacketDecoder.java
@@ -17,7 +17,6 @@
 package org.apache.activemq.artemis.core.protocol;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
-import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.message.impl.CoreMessage;
 import org.apache.activemq.artemis.core.protocol.core.CoreRemotingConnection;
 import org.apache.activemq.artemis.core.protocol.core.Packet;
@@ -54,7 +53,6 @@ import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionReq
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionSendLargeMessage;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionSendMessage;
 import org.apache.activemq.artemis.core.protocol.core.impl.wireformat.SessionSendMessage_1X;
-import org.apache.activemq.artemis.utils.collections.TypedProperties;
 
 import static org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl.BACKUP_REQUEST;
 import static org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl.BACKUP_REQUEST_RESPONSE;
@@ -85,34 +83,15 @@ import static org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl.SES
 
 public class ServerPacketDecoder extends ClientPacketDecoder {
 
-   private static final int UUID_LENGTH = 36;
-   private static final int DEFAULT_INTERNER_CAPACITY = 32;
    private static final long serialVersionUID = 3348673114388400766L;
-   private SimpleString.Interner keysInterner;
-   private TypedProperties.StringValue.Interner valuesInterner;
-
-   public ServerPacketDecoder() {
-      this.keysInterner = null;
-      this.valuesInterner = null;
-   }
-
-   private void initializeInternersIfNeeded() {
-      if (this.keysInterner == null) {
-         this.keysInterner = new SimpleString.Interner(DEFAULT_INTERNER_CAPACITY, UUID_LENGTH);
-      }
-      if (this.valuesInterner == null) {
-         this.valuesInterner = new TypedProperties.StringValue.Interner(DEFAULT_INTERNER_CAPACITY, UUID_LENGTH);
-      }
-   }
 
    private SessionSendMessage decodeSessionSendMessage(final ActiveMQBuffer in, CoreRemotingConnection connection) {
       final SessionSendMessage sendMessage;
 
-      initializeInternersIfNeeded();
       if (connection.isVersionBeforeAddressChange()) {
-         sendMessage = new SessionSendMessage_1X(new CoreMessage(this.keysInterner, this.valuesInterner));
+         sendMessage = new SessionSendMessage_1X(new CoreMessage(this.coreMessageObjectPools));
       } else {
-         sendMessage = new SessionSendMessage(new CoreMessage(this.keysInterner, this.valuesInterner));
+         sendMessage = new SessionSendMessage(new CoreMessage(this.coreMessageObjectPools));
       }
 
       sendMessage.decode(in);


### PR DESCRIPTION
* Move byte util code into ByteUtil
* Re-use the new equals method in SimpleString
* Apply same pools/interners to client decode
* Create String to SimpleString pools/interners for property access via String keys (producer and consumer benefits)
* Lazy init the pools on withing the get methods of CoreMessageObjectPools to get the specific pool, to avoid having this scattered every where.