### PR TITLE
Pr 2523 v2

### DIFF
--- a/artemis-native/README
+++ b/artemis-native/README
@@ -1,19 +1,45 @@
+# Introduction
 
-This is a simple tutorial on compiling libActiveMQLibAIO.so
 
-DEPENDENCIES
+This is a simple tutorial about building and packaging the libartemis-native library. The libartemis-native is a thin
+layer library that interface with Linux' lib AIO library as part of the journaling feature of the broker when operating
+with AIO journal.
 
-Make sure you install these packages:
+The lib AIO is a Linux-specific dependency, therefore having a relatively modern Linux operating system is assumed for
+the purpose of this documentation.
 
-- G++ (yum install gcc-c++ or aptitude install g++)
-- Gcc (yum install gcc or aptitude install gcc)
+## Dependencies
+
+In order to build the package, make sure you install these packages:
+
+- The GNU compiler library container both the C and C++ compiler
+- The GNU C library
+- The respective libaio package for your Linux distribution
 - JDK (full JDK)
 
-For cross-compilation, the 32-bits version of the aforementioned packages should be installed as well.
 
-LIBAIO INFORMATION
+For example, on Fedora Linux, compilation of the library requires the following specific packages:
 
-libaio is part of the kernel project. The library makes system calls on the kernel layer.
+- glibc-devel
+- libaio-devel
+- gcc
+- gcc-g++
+- java-1.8.0-openjdk-devel
+
+### Cross compilation
+
+Using a 64-bit Linux OS, it is possible to cross-compile the 32-bit version of the library. For this, the 32-bits
+version of the GNU C Library and lib AIO should be installed.
+
+Once again using Fedora Linux as an example, it would mean that the following packages need to be installed:
+
+- glibc-devel.i686
+- libaio-devel.i686
+
+## Lib AIO Information
+
+The Lib AIO is the Linux' Kernel Asynchronous I/O Support Library. It is part of the kernel project. The library makes
+system calls on the kernel layer.
 
 This is the project information:
 
@@ -21,13 +47,13 @@ Git Repository:  git://git.kernel.org/pub/scm/libs/libaio/libaio.git
 Mailing List:    linux-aio@kvack.org
 
 
-STEPS TO BUILD
+## Steps to build
 
 1. Make sure you have JAVA_HOME defined, and pointing to the root of your JDK:
 
 Example:
 
- $> export JAVA_HOME=/usr/share/jdk1.7
+```export JAVA_HOME=/usr/share/jdk1.7```
 
 
 2. Call compile-native.sh. Bootstrap will call all the initial scripts you need
@@ -36,12 +62,12 @@ Example:
 if you are missing any dependencies, autoconf would tell you what you're missing.
 
 
-COMPILED FILE
+### Compiled File
 
 The produced file will be under the ./target/nar (example: ./target/nar/artemis-native-1.0.0-amd64-Linux-gpp-jni/lib/amd64-Linux-gpp/jni/libartemis-native-1.0.0.so)
 and you will have to rename it manually under ./bin following the appropriate pattern.
 
-ADVANCED COMPILATION METHODS
+### Advanced Compilation Methods and Developer-specific Documentation
 
 Passing additional options to the compiler:
 ```cmake -DCMAKE_USER_C_FLAGS="-fomit-frame-pointer" -DCMAKE_VERBOSE_MAKEFILE=On .```
@@ -56,6 +82,6 @@ Cross-compilation with debugging symbols:
 ```cmake -DCMAKE_VERBOSE_MAKEFILE=On -DCMAKE_USER_C_FLAGS="-m32" -DARTEMIS_CROSS_COMPILE=On -DARTEMIS_CROSS_COMPILE_ROOT_PATH=/usr/lib .```
 
 
-DOCUMENTATION
+## Lib AIO Documentation
 
 The User Manual, chapter 38 (Libaio Native Libraries) will provide more details about our native libraries on libaio.

--- a/artemis-native/README
+++ b/artemis-native/README
@@ -40,6 +40,13 @@ COMPILED FILE
 The produced file will be under the ./target/nar (example: ./target/nar/artemis-native-1.0.0-amd64-Linux-gpp-jni/lib/amd64-Linux-gpp/jni/libartemis-native-1.0.0.so)
 and you will have to rename it manually under ./bin following the appropriate pattern.
 
+ADVANCED COMPILATION METHODS
+
+Passing additional options to the compiler:
+```cmake -DCMAKE_USER_C_FLAGS="-fomit-frame-pointer" -DCMAKE_VERBOSE_MAKEFILE=On .```
+
+Compiling with debug options:
+```cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_VERBOSE_MAKEFILE=On .```
 
 DOCUMENTATION
 

--- a/artemis-native/README
+++ b/artemis-native/README
@@ -6,9 +6,10 @@ DEPENDENCIES
 Make sure you install these packages:
 
 - G++ (yum install gcc-c++ or aptitude install g++)
-- Gcc (yum insall gcc or aptitude install gcc)
+- Gcc (yum install gcc or aptitude install gcc)
 - JDK (full JDK)
 
+For cross-compilation, the 32-bits version of the aforementioned packages should be installed as well.
 
 LIBAIO INFORMATION
 
@@ -47,6 +48,13 @@ Passing additional options to the compiler:
 
 Compiling with debug options:
 ```cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_VERBOSE_MAKEFILE=On .```
+
+Cross-compilation:
+```cmake -DCMAKE_VERBOSE_MAKEFILE=On -DCMAKE_USER_C_FLAGS="-m32" -DARTEMIS_CROSS_COMPILE=On -DARTEMIS_CROSS_COMPILE_ROOT_PATH=/usr/lib .```
+
+Cross-compilation with debugging symbols:
+```cmake -DCMAKE_VERBOSE_MAKEFILE=On -DCMAKE_USER_C_FLAGS="-m32" -DARTEMIS_CROSS_COMPILE=On -DARTEMIS_CROSS_COMPILE_ROOT_PATH=/usr/lib .```
+
 
 DOCUMENTATION
 

--- a/artemis-native/src/main/c/CMakeLists.txt
+++ b/artemis-native/src/main/c/CMakeLists.txt
@@ -42,6 +42,10 @@ endif()
 set(ARTEMIS_CROSS_COMPILE OFF CACHE BOOL "Cross-compile the native library")
 
 if (ARTEMIS_CROSS_COMPILE)
+    if (CMAKE_SIZEOF_VOID_P EQUAL 4)
+        message(FATAL_ERROR "Cannot cross-compile to 32-bit architecture in a 32-bit architecture")
+    endif()
+
     message(STATUS "Using cross-compilation")
     set(ARTEMIS_CROSS_COMPILE_ROOT_PATH /usr/lib)
     set(ARTEMIS_LIB_NAME artemis-native-32)

--- a/artemis-native/src/main/c/CMakeLists.txt
+++ b/artemis-native/src/main/c/CMakeLists.txt
@@ -28,11 +28,10 @@ if (JNI_FOUND)
     message (STATUS "JNI_LIBRARIES=${JNI_LIBRARIES}")
 endif()
 
-# you may want to remove this next line for debugging
-# -O3 would make inline debug hard
-#ADD_DEFINITIONS("-O3 -Wall -z execstack")
-ADD_DEFINITIONS("-O3 -Wall")
-#ADD_DEFINITIONS("-fdump-tree-all -Wall -pg -g")
+# You may want to adjust this next line for debugging. The -O3 is removed by default, since it would make debugging
+# harder. Nonetheless, it can still be added by passing CMAKE_USER_C_FLAGS
+set(CMAKE_C_FLAGS_DEBUG "-Wall -z execstack -fdump-tree-all -Wall -pg -g ${CMAKE_USER_C_FLAGS}")
+set(CMAKE_C_FLAGS "-O3 -Wall ${CMAKE_USER_C_FLAGS}")
 
 find_library(LIBAIO_LIB NAMES aio)
 

--- a/artemis-native/src/main/c/CMakeLists.txt
+++ b/artemis-native/src/main/c/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 ADD_DEFINITIONS("-O3 -Wall")
 #ADD_DEFINITIONS("-fdump-tree-all -Wall -pg -g")
 
-find_library(LIBAIO NAMES aio)
+find_library(LIBAIO_LIB NAMES aio)
 
 INCLUDE_DIRECTORIES(. ${JNI_INCLUDE_DIRS})
 
@@ -46,7 +46,7 @@ ADD_CUSTOM_COMMAND(
 
 ADD_LIBRARY(artemis-native SHARED org_apache_activemq_artemis_jlibaio_LibaioContext.c org_apache_activemq_artemis_jlibaio_LibaioContext.h exception_helper.h)
 
-target_link_libraries(artemis-native aio)
+target_link_libraries(artemis-native ${LIBAIO_LIB})
 
 set_target_properties(artemis-native PROPERTIES
          LIBRARY_OUTPUT_DIRECTORY ../../../bin)

--- a/artemis-native/src/main/c/CMakeLists.txt
+++ b/artemis-native/src/main/c/CMakeLists.txt
@@ -33,7 +33,21 @@ endif()
 set(CMAKE_C_FLAGS_DEBUG "-Wall -z execstack -fdump-tree-all -Wall -pg -g ${CMAKE_USER_C_FLAGS}")
 set(CMAKE_C_FLAGS "-O3 -Wall ${CMAKE_USER_C_FLAGS}")
 
+set(ARTEMIS_LIB_NAME artemis-native-64)
+set(ARTEMIS_CROSS_COMPILE OFF CACHE BOOL "Cross-compile the native library")
+
+if (ARTEMIS_CROSS_COMPILE)
+    message(STATUS "Using cross-compilation")
+    set(ARTEMIS_CROSS_COMPILE_ROOT_PATH /usr/lib)
+    set(ARTEMIS_LIB_NAME artemis-native-32)
+
+    # The Cmake variable CMAKE_FIND_ROOT_PATH cannot be set via CLI, so we have to use a separate variable and then
+    # set it to that value. We use ARTEMIS_CROSS_COMPILE_ROOT_PATH for that.
+    set(CMAKE_FIND_ROOT_PATH ${ARTEMIS_CROSS_COMPILE_ROOT_PATH})
+endif()
+
 find_library(LIBAIO_LIB NAMES aio)
+message(STATUS "Using the following libaio library for linking: ${LIBAIO_LIB}")
 
 INCLUDE_DIRECTORIES(. ${JNI_INCLUDE_DIRS})
 
@@ -48,17 +62,6 @@ ADD_LIBRARY(artemis-native SHARED org_apache_activemq_artemis_jlibaio_LibaioCont
 target_link_libraries(artemis-native ${LIBAIO_LIB})
 
 set_target_properties(artemis-native PROPERTIES
-         LIBRARY_OUTPUT_DIRECTORY ../../../bin)
-
-# It is weird but this is how you are supposed to validate between 32 and 64 bits architecture
-if (CMAKE_SIZEOF_VOID_P EQUAL 8)
-    set_target_properties(artemis-native PROPERTIES
-             LIBRARY_OUTPUT_DIRECTORY ../../../bin
-             LIBRARY_OUTPUT_NAME artemis-native-64)
-   message("-- Setting up library as artemis-native-64 based on current architecture")
-else()
-    set_target_properties(artemis-native PROPERTIES
-             LIBRARY_OUTPUT_DIRECTORY ../../../bin
-             LIBRARY_OUTPUT_NAME artemis-native-32)
-   message("-- Setting up library as artemis-native-32 based on current architecture")
-endif()
+              LIBRARY_OUTPUT_DIRECTORY ../../../bin
+              LIBRARY_OUTPUT_NAME ${ARTEMIS_LIB_NAME})
+message(STATUS "Setting up library as ${ARTEMIS_LIB_NAME} based on current architecture")

--- a/artemis-native/src/main/c/CMakeLists.txt
+++ b/artemis-native/src/main/c/CMakeLists.txt
@@ -33,7 +33,12 @@ endif()
 set(CMAKE_C_FLAGS_DEBUG "-Wall -z execstack -fdump-tree-all -Wall -pg -g ${CMAKE_USER_C_FLAGS}")
 set(CMAKE_C_FLAGS "-O3 -Wall ${CMAKE_USER_C_FLAGS}")
 
+
 set(ARTEMIS_LIB_NAME artemis-native-64)
+if (CMAKE_SIZEOF_VOID_P EQUAL 4)
+    set(ARTEMIS_LIB_NAME artemis-native-32)
+endif()
+
 set(ARTEMIS_CROSS_COMPILE OFF CACHE BOOL "Cross-compile the native library")
 
 if (ARTEMIS_CROSS_COMPILE)

--- a/artemis-native/src/main/c/CMakeLists.txt
+++ b/artemis-native/src/main/c/CMakeLists.txt
@@ -30,8 +30,10 @@ endif()
 
 # You may want to adjust this next line for debugging. The -O3 is removed by default, since it would make debugging
 # harder. Nonetheless, it can still be added by passing CMAKE_USER_C_FLAGS
-set(CMAKE_C_FLAGS_DEBUG "-Wall -z execstack -fdump-tree-all -Wall -pg -g ${CMAKE_USER_C_FLAGS}")
-set(CMAKE_C_FLAGS "-O3 -Wall ${CMAKE_USER_C_FLAGS}")
+# Also note that define the C99 as the minimum supported standard so the code can be compiled with older GCC versions
+# (circa 4.4)
+set(CMAKE_C_FLAGS_DEBUG "-Wall -std=c99 -z execstack -fdump-tree-all -Wall -pg -g ${CMAKE_USER_C_FLAGS}")
+set(CMAKE_C_FLAGS "-O3 -std=c99 -Wall ${CMAKE_USER_C_FLAGS}")
 
 
 set(ARTEMIS_LIB_NAME artemis-native-64)


### PR DESCRIPTION
Pretty much the same as in the previous PR, but this time it does not contain the barrier code. Only the cross-compilation bits + documentation updates. One minor fix is that the code sets the C standard to C99 so that it can be compiled in older GCC versions such as the one used on RHEL 6. This brings no changes to the generated runtime.

Also, it retains the current behavior so that the code compiles to the current system architecture if none is given. 